### PR TITLE
Read path config directly

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "vendor/openvr"]
 	path = vendor/openvr
 	url = https://github.com/ValveSoftware/openvr.git
-[submodule "vendor/boost-process"]
-	path = vendor/boost-process
-	url = https://github.com/OSVR/boost-process.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,10 +32,6 @@ target_link_libraries(boost_filesystem_v3
 target_compile_definitions(boost_filesystem_v3 INTERFACE BOOST_FILESYSTEM_VERSION=3)
 target_include_directories(boost_filesystem_v3 INTERFACE ${Boost_INCLUDE_DIRS})
 
-add_library(boost_process INTERFACE)
-target_include_directories(boost_process INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/vendor/boost-process" ${Boost_INCLUDE_DIRS})
-target_link_libraries(boost_process INTERFACE ${Boost_SYSTEM_LIBRARIES} ${Boost_IOSTREAMS_LIBRARIES} ${Boost_FILESYSTEM_LIBRARIES})
-
 add_library(linkable_into_dll INTERFACE)
 target_compile_options(linkable_into_dll INTERFACE ${CMAKE_SHARED_LIBRARY_CXX_FLAGS})
 
@@ -102,7 +98,7 @@ target_link_libraries(ViveLoaderLib
     PUBLIC
     OpenVRDriver osvr::osvrUtil linkable_into_dll
     PRIVATE
-    filesystem_lib boost_process JsonCpp::JsonCpp)
+    filesystem_lib JsonCpp::JsonCpp)
 target_include_directories(ViveLoaderLib PUBLIC ${CMAKE_CURRENT_BINARY_DIRECTORY} PRIVATE ${Boost_INCLUDE_DIRS})
 
 # Build the plugin

--- a/FindDriver.h
+++ b/FindDriver.h
@@ -45,10 +45,30 @@ namespace vive {
         std::string driverFile;
         std::string driverName;
 
-        /// If this field is false, the other field contain invalid data -
+        /// If this field is false, the other fields contain invalid data -
         /// the driver could not be found.
         bool found = false;
     };
+
+    struct LocationInfo {
+        std::string steamVrRoot;
+        std::string driverRoot;
+        std::string driverFile;
+        std::string driverName;
+        bool driverFound = false;
+
+        std::string rootConfigDir;
+        std::string driverConfigDir;
+        bool configFound = false;
+
+        /// If this field is false, the other fields may contain invalid data -
+        /// the driver could not be found.
+        bool found = false;
+    };
+
+    /// Get the location information on the given driver, including config info.
+    LocationInfo findLocationInfoForDriver(
+        std::string const &driver = std::string(DRIVER_NAME));
 
     /// Get the location information on the given driver
     DriverLocationInfo

--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ These may be useful in keeping track of upstream changes to the lighthouse drive
 This plugin: Licensed under the Apache License, Version 2.0.
 
 Vendored projects:
-- `boost-process` (incubator/under review) - Boost Software License 1.0
 - Valve SteamVR `openvr` (specifically `openvr_driver` headers) - MIT license.
 
-Note: At runtime, this plugin dynamically loads the Lighthouse SteamVR plugin distributed with SteamVR, runs the `vrpathreg` tool included with SteamVR and parses its output, as well as loads some SteamVR configuration settings (room calibration, etc) from JSON files.
+Note: At runtime, this plugin dynamically loads the Lighthouse SteamVR plugin distributed with SteamVR, as well as loads some SteamVR configuration settings (room calibration, etc) from JSON files.


### PR DESCRIPTION
This fixes #6, and also includes a patch to address the bitness part of #5 since it was in the same file. Now we read the same JSON config file that SteamVR does, rather than parsing the output of running a steamvr executable: we get more/better information all at once, and aren't dependent on the specific output format of the tool not changing. 