### PR TITLE
Linux/MacOSX port of DriverLoader

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,9 +100,9 @@ add_library(ViveLoaderLib STATIC
     VRSettings.h)
 target_link_libraries(ViveLoaderLib
     PUBLIC
-    OpenVRDriver osvr::osvrUtil linkable_into_dll ${CMAKE_DL_LIBS}
+    OpenVRDriver osvr::osvrUtil linkable_into_dll
     PRIVATE
-    filesystem_lib JsonCpp::JsonCpp)
+    filesystem_lib JsonCpp::JsonCpp ${CMAKE_DL_LIBS}) # ${CMAKE_DL_LIBS} is set to empty string, when system doesn't provide dlfcn. For example, Windows.
 target_include_directories(ViveLoaderLib PUBLIC ${CMAKE_CURRENT_BINARY_DIRECTORY} PRIVATE ${Boost_INCLUDE_DIRS})
 
 # Build the plugin

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,7 +100,7 @@ add_library(ViveLoaderLib STATIC
     VRSettings.h)
 target_link_libraries(ViveLoaderLib
     PUBLIC
-    OpenVRDriver osvr::osvrUtil linkable_into_dll
+    OpenVRDriver osvr::osvrUtil linkable_into_dll ${CMAKE_DL_LIBS}
     PRIVATE
     filesystem_lib JsonCpp::JsonCpp)
 target_include_directories(ViveLoaderLib PUBLIC ${CMAKE_CURRENT_BINARY_DIRECTORY} PRIVATE ${Boost_INCLUDE_DIRS})

--- a/ChaperoneData.cpp
+++ b/ChaperoneData.cpp
@@ -37,6 +37,7 @@
 #include <iostream>
 #include <map>
 #include <sstream>
+#include <algorithm>
 
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
@@ -100,6 +101,7 @@ getFile(std::string const &fn,
     return os.str();
 }
 #else
+#include <cstring> // strerror
 
 std::string
 getFile(std::string const &fn,
@@ -119,7 +121,7 @@ getFile(std::string const &fn,
     }
     std::ostringstream os;
     std::string temp;
-    while (std::getline(os, temp)) {
+    while (std::getline(s, temp)) {
         os << temp;
     }
     return os.str();

--- a/DisplayDescriptor.cpp
+++ b/DisplayDescriptor.cpp
@@ -26,6 +26,7 @@
 
 // Internal Includes
 #include "DisplayDescriptor.h"
+#include "osvr/Util/PlatformConfig.h"
 
 // Library/third-party includes
 #include <json/reader.h>
@@ -36,6 +37,10 @@
 #include <algorithm>
 #include <cmath>
 #include <iostream>
+
+#if defined(OSVR_LINUX) || defined(OSVR_MACOSX)
+#include <float.h> // FLT_EPSILON
+#endif
 
 namespace osvr {
 namespace vive {

--- a/DriverLoader.cpp
+++ b/DriverLoader.cpp
@@ -34,11 +34,15 @@
 #include <iostream>
 
 #if defined(OSVR_WINDOWS)
+
 #define WIN32_LEAN_AND_MEAN
 #define NO_MINMAX
 #include <windows.h>
+
 #elif defined(OSVR_LINUX) || defined(OSVR_MACOSX)
+
 #include <dlfcn.h>
+
 #endif
 
 namespace osvr {
@@ -103,7 +107,7 @@ namespace vive {
             reset();
             throw CouldNotLoadEntryPoint(dlerror());
         }
-        factory_ = reinterpret_cast<DriverFactory>(proc);                                                                       \
+        factory_ = reinterpret_cast<DriverFactory>(proc);
 #endif
     }
 

--- a/DriverLoader.cpp
+++ b/DriverLoader.cpp
@@ -37,6 +37,10 @@
 #define WIN32_LEAN_AND_MEAN
 #define NO_MINMAX
 #include <windows.h>
+#elif defined(OSVR_LINUX)
+#include <dlfcn.h>
+#elif defined(OSVR_MACOSX)
+#include <dlfcn.h>
 #endif
 
 namespace osvr {
@@ -48,10 +52,8 @@ namespace vive {
 /// Platform-specific handle to dynamic library
 #if defined(OSVR_WINDOWS)
         HMODULE driver_ = nullptr;
-#elif defined(OSVR_MACOSX)
-#error "Implementation incomplete!"
-#elif defined(OSVR_LINUX)
-#error "Implementation incomplete!"
+#elif defined(OSVR_MACOSX) || defined(OSVR_LINUX)
+        void *driver_ = nullptr;
 #endif
 
         /// Destructor: should contain platform-specific code to unload dynamic
@@ -61,10 +63,10 @@ namespace vive {
             if (driver_) {
                 FreeLibrary(driver_);
             }
-#elif defined(OSVR_MACOSX)
-#error "Implementation incomplete! Unload dynamic library here!"
-#elif defined(OSVR_LINUX)
-#error "Implementation incomplete! Unload dynamic library here!"
+#elif defined(OSVR_MACOSX) || defined(OSVR_LINUX)
+            if (driver_) {
+                dlclose(driver_);
+            }
 #endif
         }
     };
@@ -91,12 +93,19 @@ namespace vive {
             throw CouldNotLoadEntryPoint();
         }
         factory_ = reinterpret_cast<DriverFactory>(proc);
-#elif defined(OSVR_MACOSX)
-#error                                                                         \
-    "Implementation incomplete! Load dynamic library here and retrieve entry point function here!"
-#elif defined(OSVR_LINUX)
-#error                                                                         \
-    "Implementation incomplete! Load dynamic library here and retrieve entry point function here!"
+#elif defined(OSVR_LINUX) || defined(OSVR_MACOSX)
+        impl_->driver_ = dlopen(driverFile.c_str());
+        if (!impl_->driver_) {
+            reset();
+            throw CouldNotLoadDriverModule(dlerror());
+        }
+
+        auto proc = dlsym(impl_->driver_, ENTRY_POINT_FUNCTION_NAME);
+        if (!proc) {
+            reset();
+            throw CouldNotLoadEntryPoint(dlerror());
+        }
+        factory_ = reinterpret_cast<DriverFactory>(proc);                                                                       \
 #endif
     }
 

--- a/DriverLoader.cpp
+++ b/DriverLoader.cpp
@@ -92,7 +92,7 @@ namespace vive {
         }
         factory_ = reinterpret_cast<DriverFactory>(proc);
 #elif defined(OSVR_LINUX) || defined(OSVR_MACOSX)
-        impl_->driver_ = dlopen(driverFile.c_str());
+        impl_->driver_ = dlopen(driverFile.c_str(), RTLD_NOW | RTLD_GLOBAL);
         if (!impl_->driver_) {
             reset();
             throw CouldNotLoadDriverModule(dlerror());

--- a/DriverLoader.cpp
+++ b/DriverLoader.cpp
@@ -37,9 +37,7 @@
 #define WIN32_LEAN_AND_MEAN
 #define NO_MINMAX
 #include <windows.h>
-#elif defined(OSVR_LINUX)
-#include <dlfcn.h>
-#elif defined(OSVR_MACOSX)
+#elif defined(OSVR_LINUX) || defined(OSVR_MACOSX)
 #include <dlfcn.h>
 #endif
 

--- a/DriverLoader.h
+++ b/DriverLoader.h
@@ -26,7 +26,7 @@
 #define INCLUDED_DriverLoader_h_GUID_882F2FD5_F218_42BE_3088_31CF712EC455
 
 // Internal Includes
-// - none
+#include <osvr/Util/PlatformDefines.h>
 
 // Library/third-party includes
 // - none
@@ -43,7 +43,7 @@ namespace vive {
 #if defined(OSVR_LINUX) || defined(OSVR_MACOSX)
         CouldNotLoadDriverModule(const char *errString)
             : std::runtime_error(
-                  "Could not load driver module." + 
+                  "Could not load driver module: " +
                    std::string(errString)) {}
 #else
         CouldNotLoadDriverModule()
@@ -55,7 +55,7 @@ namespace vive {
 #if defined(OSVR_LINUX) || defined(OSVR_MACOSX)
         CouldNotLoadEntryPoint(const char *errString)
             : std::runtime_error(
-                  "Could not load entry point function from driver." + 
+                  "Could not load entry point function from driver: " +
                    std::string(errString)) {}
 #else
         CouldNotLoadEntryPoint()

--- a/DriverLoader.h
+++ b/DriverLoader.h
@@ -26,7 +26,8 @@
 #define INCLUDED_DriverLoader_h_GUID_882F2FD5_F218_42BE_3088_31CF712EC455
 
 // Internal Includes
-#include <osvr/Util/PlatformDefines.h>
+#include <osvr/Util/PlatformConfig.h>
+#include <InterfaceTraits.h>
 
 // Library/third-party includes
 // - none
@@ -40,25 +41,23 @@
 namespace osvr {
 namespace vive {
     struct CouldNotLoadDriverModule : std::runtime_error {
+        CouldNotLoadDriverModule(const char *errString = nullptr)
 #if defined(OSVR_LINUX) || defined(OSVR_MACOSX)
-        CouldNotLoadDriverModule(const char *errString)
             : std::runtime_error(
                   "Could not load driver module: " +
                    std::string(errString)) {}
 #else
-        CouldNotLoadDriverModule()
             : std::runtime_error("Could not load driver module.") {}
 #endif
     };
 
     struct CouldNotLoadEntryPoint : std::runtime_error {
+        CouldNotLoadEntryPoint(const char *errString = nullptr)
 #if defined(OSVR_LINUX) || defined(OSVR_MACOSX)
-        CouldNotLoadEntryPoint(const char *errString)
             : std::runtime_error(
                   "Could not load entry point function from driver: " +
                    std::string(errString)) {}
 #else
-        CouldNotLoadEntryPoint()
             : std::runtime_error(
                   "Could not load entry point function from driver.") {}
 #endif

--- a/DriverLoader.h
+++ b/DriverLoader.h
@@ -40,14 +40,28 @@
 namespace osvr {
 namespace vive {
     struct CouldNotLoadDriverModule : std::runtime_error {
+#if defined(OSVR_LINUX) || defined(OSVR_MACOSX)
+        CouldNotLoadDriverModule(const char *errString)
+            : std::runtime_error(
+                  "Could not load driver module." + 
+                   std::string(errString)) {}
+#else
         CouldNotLoadDriverModule()
             : std::runtime_error("Could not load driver module.") {}
+#endif
     };
 
     struct CouldNotLoadEntryPoint : std::runtime_error {
+#if defined(OSVR_LINUX) || defined(OSVR_MACOSX)
+        CouldNotLoadEntryPoint(const char *errString)
+            : std::runtime_error(
+                  "Could not load entry point function from driver." + 
+                   std::string(errString)) {}
+#else
         CouldNotLoadEntryPoint()
             : std::runtime_error(
                   "Could not load entry point function from driver.") {}
+#endif
     };
 
     struct CouldNotGetInterface : std::runtime_error {

--- a/DriverLoader.h
+++ b/DriverLoader.h
@@ -41,26 +41,22 @@
 namespace osvr {
 namespace vive {
     struct CouldNotLoadDriverModule : std::runtime_error {
-        CouldNotLoadDriverModule(const char *errString = nullptr)
-#if defined(OSVR_LINUX) || defined(OSVR_MACOSX)
+        CouldNotLoadDriverModule(const char *errString)
             : std::runtime_error(
                   "Could not load driver module: " +
                    std::string(errString)) {}
-#else
+        CouldNotLoadDriverModule()
             : std::runtime_error("Could not load driver module.") {}
-#endif
     };
 
     struct CouldNotLoadEntryPoint : std::runtime_error {
-        CouldNotLoadEntryPoint(const char *errString = nullptr)
-#if defined(OSVR_LINUX) || defined(OSVR_MACOSX)
+        CouldNotLoadEntryPoint(const char *errString)
             : std::runtime_error(
                   "Could not load entry point function from driver: " +
                    std::string(errString)) {}
-#else
+        CouldNotLoadEntryPoint()
             : std::runtime_error(
                   "Could not load entry point function from driver.") {}
-#endif
     };
 
     struct CouldNotGetInterface : std::runtime_error {

--- a/FindDriver.cpp
+++ b/FindDriver.cpp
@@ -47,6 +47,7 @@
 #include <shlobj.h>
 #else
 #include <cstdlib> // for getenv
+#include <fstream> // std::ifstream
 #endif
 
 #undef VIVELOADER_VERBOSE

--- a/SearchPathExtender.h
+++ b/SearchPathExtender.h
@@ -101,7 +101,7 @@ namespace vive {
 #ifdef _MSC_VER
             _putenv_s(SEARCH_PATH_ENV, val.c_str());
 #else // not microsoft runtime specific
-            auto newValue = SEARCH_PATH_ENV + "=" + val;
+            auto newValue = SEARCH_PATH_ENV + std::string("=") + val;
             // Have to allocate new string because it becomes part of the
             // environment.
             char *newString = static_cast<char *>(malloc(newValue.size() + 1));


### PR DESCRIPTION
Not tested this at all. But this must work on Linux and OSX too, since they are provide same POSIX dlfcn.h.

Also here is little changes in exceptions, because it's too important to know why library isn't loaded. 

This must be compiled with `-ldl`. (`${CMAKE_DL_LIBS}` variable in CMake)