### PR TITLE
Update OpenVR to latest commit (based on 0.9.21)

### DIFF
--- a/DisplayExtractor.cpp
+++ b/DisplayExtractor.cpp
@@ -293,8 +293,7 @@ int main() {
             std::cout << PREFIX << "Got " << numDevices
                       << " tracked devices at startup" << std::endl;
             for (decltype(numDevices) i = 0; i < numDevices; ++i) {
-                auto dev = vive.serverDevProvider().GetTrackedDeviceDriver(
-                    i, vr::ITrackedDeviceServerDriver_Version);
+                auto dev = vive.serverDevProvider().GetTrackedDeviceDriver(i);
                 vive.devices().addAndActivateDevice(dev);
                 std::cout << PREFIX << "Device " << i << std::endl;
                 auto disp =

--- a/OSVRViveTracker.cpp
+++ b/OSVRViveTracker.cpp
@@ -152,8 +152,8 @@ namespace vive {
         m_vive->serverDevProvider().LeaveStandby();
 
         auto handleNewDevice = [&](const char *serialNum) {
-            auto dev = m_vive->serverDevProvider().FindTrackedDeviceDriver(
-                serialNum, vr::ITrackedDeviceServerDriver_Version);
+            auto dev =
+                m_vive->serverDevProvider().FindTrackedDeviceDriver(serialNum);
             if (!dev) {
                 /// The only devices we usually can't look up by serial number
                 /// seem to be the lighthouse base stations.
@@ -195,8 +195,8 @@ namespace vive {
             std::cout << PREFIX << "Got " << numDevices
                       << " tracked devices at startup" << std::endl;
             for (decltype(numDevices) i = 0; i < numDevices; ++i) {
-                auto dev = m_vive->serverDevProvider().GetTrackedDeviceDriver(
-                    i, vr::ITrackedDeviceServerDriver_Version);
+                auto dev =
+                    m_vive->serverDevProvider().GetTrackedDeviceDriver(i);
                 activateDevice(dev);
             }
         }
@@ -588,8 +588,7 @@ namespace vive {
                                   true);
         }
         return std::make_pair(
-            m_vive->serverDevProvider().GetTrackedDeviceDriver(
-                unWhichDevice, vr::ITrackedDeviceServerDriver_Version),
+            m_vive->serverDevProvider().GetTrackedDeviceDriver(unWhichDevice),
             false);
     }
 


### PR DESCRIPTION
This removes the interface version argument from the
FindTrackedDeviceDriver and GetTrackedDeviceDriver calls. This does
not make use of the new GetInterfaceVersions method.