### PR TITLE
Update for steamvr changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,7 @@ add_library(ViveLoaderLib STATIC
     GetComponent.h
     GetProvider.h
     InterfaceTraits.h
+    ReturnValue.h
     SearchPathExtender.h
     ServerDriverHost.cpp
     ServerDriverHost.h

--- a/DisplayExtractor.cpp
+++ b/DisplayExtractor.cpp
@@ -314,7 +314,7 @@ int main() {
                       << " tracked devices at startup" << std::endl;
             for (decltype(numDevices) i = 0; i < numDevices; ++i) {
                 auto dev = vive.serverDevProvider().GetTrackedDeviceDriver(
-                    i, vr::ITrackedDeviceServerDriver_Version);
+                    i);
                 vive.devices().addAndActivateDevice(dev);
                 std::cout << PREFIX << "Device " << i << std::endl;
                 auto disp =

--- a/DisplayExtractor.cpp
+++ b/DisplayExtractor.cpp
@@ -286,6 +286,26 @@ int main() {
             return 1;
         }
 
+        if (osvr::vive::DriverWrapper::InterfaceVersionStatus::
+                InterfaceMismatch ==
+            vive.checkServerDeviceProviderInterfaces()) {
+            std::cerr << PREFIX
+                      << "SteamVR driver requires unavailable/unsupported "
+                         "interface versions - either too old or too new for "
+                         "this build. Cannot continue."
+                      << std::endl;
+            for (auto iface : vive.getUnsupportedRequestedInterfaces()) {
+                if (osvr::vive::isInterfaceNameWeCareAbout(iface)) {
+                    auto supported =
+                        vive.getSupportedInterfaceVersions()
+                            .findSupportedVersionOfInterface(iface);
+                    std::cerr << PREFIX << " - Driver requested " << iface
+                              << " but we support " << supported << std::endl;
+                }
+            }
+            return 1;
+        }
+
         /// Power the system up.
         vive.serverDevProvider().LeaveStandby();
         {

--- a/DriverLoader.cpp
+++ b/DriverLoader.cpp
@@ -129,17 +129,17 @@ namespace vive {
 
     bool DriverLoader::isHMDPresent(std::string const &userConfigDir) const {
         auto ret = getInterface<vr::IClientTrackedDeviceProvider>();
-        if (ret.first) {
+        if (ret) {
             // std::cout << "Successfully got the
             // IClientTrackedDeviceProvider!";
-            auto clientProvider = ret.first;
+            auto clientProvider = ret.value;
             auto isPresent =
                 clientProvider->BIsHmdPresent(userConfigDir.c_str());
             // std::cout << " is present? " << std::boolalpha << isPresent
             //          << std::endl;
             return isPresent;
         }
-        // std::cout << "Couldn't get it, error code " << ret.second <<
+        // std::cout << "Couldn't get it, error code " << ret.errorCode <<
         // std::endl;
         return false;
     }

--- a/GenerateTypedPropertyEnums.cpp
+++ b/GenerateTypedPropertyEnums.cpp
@@ -57,6 +57,8 @@ static const auto startOfOutput = R"(/** @file
 /*
 Copyright 2016 Razer Inc.
 
+SPDX-License-Identifier: BSD-3-Clause
+
 OpenVR input data:
 Copyright (c) 2015, Valve Corporation
 All rights reserved.

--- a/OSVRViveTracker.cpp
+++ b/OSVRViveTracker.cpp
@@ -221,8 +221,8 @@ namespace vive {
             std::cout << PREFIX << "Got " << numDevices
                       << " tracked devices at startup" << std::endl;
             for (decltype(numDevices) i = 0; i < numDevices; ++i) {
-                auto dev = m_vive->serverDevProvider().GetTrackedDeviceDriver(
-                    i, vr::ITrackedDeviceServerDriver_Version);
+                auto dev =
+                    m_vive->serverDevProvider().GetTrackedDeviceDriver(i);
                 activateDevice(dev);
             }
         }
@@ -455,7 +455,8 @@ namespace vive {
                                                OSVR_ChannelCount sensor,
                                                const DriverPose_t &newPose) {
         if (!(sensor < m_trackingResults.size())) {
-            m_trackingResults.resize(sensor + 1, vr::TrackingResult_Uninitialized);
+            m_trackingResults.resize(sensor + 1,
+                                     vr::TrackingResult_Uninitialized);
         }
 
         if (newPose.result != m_trackingResults[sensor]) {
@@ -614,8 +615,7 @@ namespace vive {
                                   true);
         }
         return std::make_pair(
-            m_vive->serverDevProvider().GetTrackedDeviceDriver(
-                unWhichDevice, vr::ITrackedDeviceServerDriver_Version),
+            m_vive->serverDevProvider().GetTrackedDeviceDriver(unWhichDevice),
             false);
     }
 

--- a/OSVRViveTracker.cpp
+++ b/OSVRViveTracker.cpp
@@ -150,6 +150,30 @@ namespace vive {
             return StartResult::PermanentFailure;
         }
 
+        /// Check for interface compatibility
+        if (DriverWrapper::InterfaceVersionStatus::InterfaceMismatch ==
+            m_vive->checkServerDeviceProviderInterfaces()) {
+            std::cerr
+                << PREFIX
+                << "SteamVR lighthouse driver requires unavailable/unsupported "
+                   "interface versions - either too old or too new for "
+                   "this build. Specifically, the following critical "
+                   "mismatches: "
+                << std::endl;
+            for (auto iface : m_vive->getUnsupportedRequestedInterfaces()) {
+                if (isInterfaceNameWeCareAbout(
+                        detail::getInterfaceName(iface))) {
+                    auto supported =
+                        m_vive->getSupportedInterfaceVersions()
+                            .findSupportedVersionOfInterface(iface);
+                    std::cerr << PREFIX << " - SteamVR lighthouse: " << iface
+                              << "\t\t OSVR-Vive: " << supported << std::endl;
+                }
+            }
+            std::cerr << PREFIX << "Cannot continue.\n" << std::endl;
+            return StartResult::PermanentFailure;
+        }
+
         /// Power the system up.
         m_vive->serverDevProvider().LeaveStandby();
 
@@ -584,7 +608,7 @@ namespace vive {
 
     std::pair<vr::ITrackedDeviceServerDriver *, bool>
     ViveDriverHost::getDriverPtr(uint32_t unWhichDevice) {
-        return std::pair<vr::ITrackedDeviceServerDriver *, bool>();
+        // return std::pair<vr::ITrackedDeviceServerDriver *, bool>();
         if (m_vive->devices().hasDeviceAt(unWhichDevice)) {
             return std::make_pair(&(m_vive->devices().getDevice(unWhichDevice)),
                                   true);

--- a/OSVRViveTracker.h
+++ b/OSVRViveTracker.h
@@ -28,6 +28,7 @@
 
 // Internal Includes
 #include "QuickProcessingDeque.h"
+#include "ReturnValue.h"
 #include "ServerDriverHost.h"
 #include <osvr/PluginKit/AnalogInterfaceC.h>
 #include <osvr/PluginKit/ButtonInterfaceC.h>
@@ -87,7 +88,9 @@ namespace vive {
         EIGEN_MAKE_ALIGNED_OPERATOR_NEW
         ViveDriverHost();
 
+        using DevIdReturnValue = ReturnValue<std::uint32_t, bool>;
         enum class StartResult { Success, TemporaryFailure, PermanentFailure };
+
         /// @return false if we failed to start up for some reason.
         StartResult start(OSVR_PluginRegContext ctx,
                           osvr::vive::DriverWrapper &&inVive);
@@ -98,8 +101,7 @@ namespace vive {
         /// Called when we get a new device from the SteamVR driver that we need
         /// to activate. Delegates the real work - this just displays
         /// information.
-        std::pair<bool, std::uint32_t>
-        activateDevice(vr::ITrackedDeviceServerDriver *dev);
+        DevIdReturnValue activateDevice(vr::ITrackedDeviceServerDriver *dev);
 
         /// @name ServerDriverHost overrides - called from a tracker thread (not
         /// the main thread)
@@ -170,7 +172,7 @@ namespace vive {
                                              bool state);
 
         /// Does the real work of adding a new device.
-        std::pair<bool, std::uint32_t>
+        DevIdReturnValue
         activateDeviceImpl(vr::ITrackedDeviceServerDriver *dev);
 
         osvr::pluginkit::DeviceToken m_dev;

--- a/OSVRViveTracker.h
+++ b/OSVRViveTracker.h
@@ -87,9 +87,10 @@ namespace vive {
         EIGEN_MAKE_ALIGNED_OPERATOR_NEW
         ViveDriverHost();
 
+        enum class StartResult { Success, TemporaryFailure, PermanentFailure };
         /// @return false if we failed to start up for some reason.
-        bool start(OSVR_PluginRegContext ctx,
-                   osvr::vive::DriverWrapper &&inVive);
+        StartResult start(OSVR_PluginRegContext ctx,
+                          osvr::vive::DriverWrapper &&inVive);
 
         /// Standard OSVR device callback
         OSVR_ReturnCode update();

--- a/PropertyHelper.h
+++ b/PropertyHelper.h
@@ -1,5 +1,7 @@
 /** @file
-    @brief Header
+    @brief Header designed to build on the generated PropertyTraits.h header.
+
+    BSD-3-Clause to match the "OpenVR" and thus PropertyTraits.h license.
 
     @date 2016
 
@@ -8,25 +10,44 @@
     <http://sensics.com/osvr>
 */
 
-// Copyright 2016 Razer Inc.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//        http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/*
+SPDX-License-Identifier: BSD-3-Clause
+
+Copyright (c) 2016, Razer Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+may be used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
 
 #ifndef INCLUDED_PropertyHelper_h_GUID_08BEA00F_2E0C_4FA5_DF5B_31BE33EF27A3
 #define INCLUDED_PropertyHelper_h_GUID_08BEA00F_2E0C_4FA5_DF5B_31BE33EF27A3
 
 #include <cstddef>
 
+// Include the generated file
 #include "PropertyTraits.h"
 
 // Standard includes

--- a/PropertyTraits.h
+++ b/PropertyTraits.h
@@ -11,6 +11,8 @@
 /*
 Copyright 2016 Razer Inc.
 
+SPDX-License-Identifier: BSD-3-Clause
+
 OpenVR input data:
 Copyright (c) 2015, Valve Corporation
 All rights reserved.
@@ -87,6 +89,9 @@ namespace vive {
         Firmware_ProgrammingTarget = vr::Prop_Firmware_ProgrammingTarget_String,
         DeviceClass = vr::Prop_DeviceClass_Int32,
         HasCamera = vr::Prop_HasCamera_Bool,
+        DriverVersion = vr::Prop_DriverVersion_String,
+        Firmware_ForceUpdateRequired =
+            vr::Prop_Firmware_ForceUpdateRequired_Bool,
         ReportsTimeSinceVSync = vr::Prop_ReportsTimeSinceVSync_Bool,
         SecondsFromVsyncToPhotons = vr::Prop_SecondsFromVsyncToPhotons_Float,
         DisplayFrequency = vr::Prop_DisplayFrequency_Float,
@@ -121,6 +126,11 @@ namespace vive {
         DisplayHardwareVersion = vr::Prop_DisplayHardwareVersion_Uint64,
         AudioFirmwareVersion = vr::Prop_AudioFirmwareVersion_Uint64,
         CameraCompatibilityMode = vr::Prop_CameraCompatibilityMode_Int32,
+        ScreenshotHorizontalFieldOfViewDegrees =
+            vr::Prop_ScreenshotHorizontalFieldOfViewDegrees_Float,
+        ScreenshotVerticalFieldOfViewDegrees =
+            vr::Prop_ScreenshotVerticalFieldOfViewDegrees_Float,
+        DisplaySuppressed = vr::Prop_DisplaySuppressed_Bool,
         AttachedDeviceId = vr::Prop_AttachedDeviceId_String,
         SupportedButtons = vr::Prop_SupportedButtons_Uint64,
         Axis0Type = vr::Prop_Axis0Type_Int32,
@@ -249,6 +259,13 @@ namespace vive {
         template <> struct PropertyTypeTrait<vr::Prop_HasCamera_Bool> {
             using type = bool;
         };
+        template <> struct PropertyTypeTrait<vr::Prop_DriverVersion_String> {
+            using type = std::string;
+        };
+        template <>
+        struct PropertyTypeTrait<vr::Prop_Firmware_ForceUpdateRequired_Bool> {
+            using type = bool;
+        };
         template <>
         struct PropertyTypeTrait<vr::Prop_ReportsTimeSinceVSync_Bool> {
             using type = bool;
@@ -367,6 +384,19 @@ namespace vive {
         template <>
         struct PropertyTypeTrait<vr::Prop_CameraCompatibilityMode_Int32> {
             using type = int32_t;
+        };
+        template <>
+        struct PropertyTypeTrait<
+            vr::Prop_ScreenshotHorizontalFieldOfViewDegrees_Float> {
+            using type = float;
+        };
+        template <>
+        struct PropertyTypeTrait<
+            vr::Prop_ScreenshotVerticalFieldOfViewDegrees_Float> {
+            using type = float;
+        };
+        template <> struct PropertyTypeTrait<vr::Prop_DisplaySuppressed_Bool> {
+            using type = bool;
         };
         template <> struct PropertyTypeTrait<vr::Prop_AttachedDeviceId_String> {
             using type = std::string;

--- a/ReturnValue.h
+++ b/ReturnValue.h
@@ -1,0 +1,110 @@
+/** @file
+    @brief Header
+
+    @date 2016
+
+    @author
+    Sensics, Inc.
+    <http://sensics.com/osvr>
+*/
+
+// Copyright 2016 Sensics, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef INCLUDED_ReturnValue_h_GUID_B28A8BE9_541A_42AC_6925_C51C944B089E
+#define INCLUDED_ReturnValue_h_GUID_B28A8BE9_541A_42AC_6925_C51C944B089E
+
+// Internal Includes
+// - none
+
+// Library/third-party includes
+// - none
+
+// Standard includes
+// - none
+
+namespace osvr {
+namespace vive {
+    struct ReturnValueBase {
+        ReturnValueBase() {}
+        ReturnValueBase(bool ok) : valid(ok) {}
+
+        const bool valid = false;
+
+        /// check validity by evaluating as a bool
+        explicit operator bool() const { return valid; }
+    };
+
+    template <typename ValueType, typename ErrorCodeType>
+    struct ReturnValue : ReturnValueBase {
+        ReturnValue(ValueType const &val, ErrorCodeType err)
+            : ReturnValueBase(), value(val), errorCode(err) {}
+        ReturnValue(ValueType const &val, ErrorCodeType err, bool ok)
+            : ReturnValueBase(ok), value(val), errorCode(err) {}
+
+        ValueType value = {};
+        ErrorCodeType errorCode = {};
+
+        static ReturnValue makeError(ErrorCodeType err) {
+            return ReturnValue{{}, err};
+        }
+        static ReturnValue makeValueFromRvalue(ValueType &&val) {
+            return ReturnValue{std::move(val), {}, true};
+        }
+        static ReturnValue makeValue(ValueType val) {
+            return ReturnValue{val, {}, true};
+        }
+    };
+
+    /// specialization for bool "error codes"
+    template <typename ValueType>
+    struct ReturnValue<ValueType, bool> : ReturnValueBase {
+        ReturnValue(ValueType const &val) : ReturnValueBase(true), value(val) {}
+        ReturnValue(ValueType const &val, bool ok)
+            : ReturnValueBase(ok), value(val) {}
+
+        ValueType value = {};
+
+        static ReturnValue makeError() { return ReturnValue{{}, false}; }
+        static ReturnValue makeValueFromRvalue(ValueType &&val) {
+            return ReturnValue{std::move(val), true};
+        }
+        static ReturnValue makeValue(ValueType val) {
+            return ReturnValue{val, true};
+        }
+    };
+
+    template <typename ValueType, typename ErrorCodeType>
+    inline ReturnValue<ValueType, ErrorCodeType>
+    makeGenericReturnValue(ValueType const &val, ErrorCodeType err,
+                           bool valid) {
+        using type = ReturnValue<ValueType, ErrorCodeType>;
+        return type(val, err, valid);
+    }
+
+    template <typename ValueType, typename ErrorCodeType>
+    inline ReturnValue<ValueType, ErrorCodeType> makeError(ValueType const &val,
+                                                           ErrorCodeType err) {
+        return makeGenericReturnValue(val, err, false);
+    }
+
+    template <typename ValueType, typename ErrorCodeType>
+    inline ReturnValue<ValueType, ErrorCodeType>
+    makeReturnValue(ValueType const &val, ErrorCodeType err) {
+        return makeGenericReturnValue(val, err, true);
+    }
+
+} // namespace vive
+} // namespace osvr
+#endif // INCLUDED_ReturnValue_h_GUID_B28A8BE9_541A_42AC_6925_C51C944B089E

--- a/ServerPropertyHelper.h
+++ b/ServerPropertyHelper.h
@@ -1,5 +1,7 @@
 /** @file
-    @brief Header
+    @brief Header based on PropertyHelper for users of openvr_driver.h
+
+    BSD-3-Clause to match the "OpenVR" and thus PropertyTraits.h license.
 
     @date 2016
 
@@ -8,25 +10,45 @@
     <http://sensics.com/osvr>
 */
 
-// Copyright 2016 Sensics, Inc.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//        http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/*
+SPDX-License-Identifier: BSD-3-Clause
+
+Copyright (c) 2016, Sensics, Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+may be used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
 
 #ifndef INCLUDED_ServerPropertyHelper_h_GUID_9835023A_E639_409F_3A68_CFB4029FBBE7
 #define INCLUDED_ServerPropertyHelper_h_GUID_9835023A_E639_409F_3A68_CFB4029FBBE7
 
+// OpenVR header
 #include <openvr_driver.h>
 
+// PropertyHelper (and transitively, the generated traits header)
 #include "PropertyHelper.h"
 
 namespace osvr {

--- a/ViveLoader.cpp
+++ b/ViveLoader.cpp
@@ -202,7 +202,7 @@ int main() {
             return false;
         }
         auto ret = vive.devices().addAndActivateDevice(dev);
-        if (!ret.first) {
+        if (!ret) {
             std::cout << PREFIX << "Device with serial number " << serialNum
                       << " couldn't be added to the devices vector."
                       << std::endl;
@@ -210,7 +210,7 @@ int main() {
         }
         std::cout << "\n"
                   << PREFIX << "Device with s/n " << serialNum
-                  << " activated, assigned ID " << ret.second << std::endl;
+                  << " activated, assigned ID " << ret.value << std::endl;
         whatIsThisDevice(dev);
         return true;
     };

--- a/ViveLoader.cpp
+++ b/ViveLoader.cpp
@@ -188,13 +188,56 @@ int main() {
 
     /// but now, we can do things with vive.serverDevProvider()
 
+    /// first thing we should do is check driver compatibility.
+    auto interfaceStatus = vive.checkServerDeviceProviderInterfaces();
+    switch (interfaceStatus) {
+    case osvr::vive::DriverWrapper::InterfaceVersionStatus::AllInterfacesOK:
+        std::cerr << PREFIX << "All interface versions mentioned by the driver "
+                               "are available and supported."
+                  << std::endl;
+        break;
+    case osvr::vive::DriverWrapper::InterfaceVersionStatus::AllUsedInterfacesOK:
+        std::cerr << PREFIX << "Not all interface versions mentioned by the "
+                               "driver are available and supported, but the "
+                               "ones used by this code match."
+                  << std::endl;
+        break;
+    case osvr::vive::DriverWrapper::InterfaceVersionStatus::InterfaceMismatch:
+        std::cerr
+            << PREFIX
+            << "Driver requires unavailable/unsupported interface versions."
+            << std::endl;
+        break;
+    default:
+        break;
+    }
+
+    switch (interfaceStatus) {
+    case osvr::vive::DriverWrapper::InterfaceVersionStatus::AllUsedInterfacesOK:
+    case osvr::vive::DriverWrapper::InterfaceVersionStatus::InterfaceMismatch:
+        std::cerr << PREFIX
+                  << "Unavailable interface version strings:" << std::endl;
+        for (auto iface : vive.getUnsupportedRequestedInterfaces()) {
+            std::cerr << PREFIX << " - " << iface << std::endl;
+        }
+        break;
+    case osvr::vive::DriverWrapper::InterfaceVersionStatus::AllInterfacesOK:
+    default:
+        break;
+    }
+
+    if (osvr::vive::DriverWrapper::InterfaceVersionStatus::InterfaceMismatch ==
+        interfaceStatus) {
+        std::cerr << PREFIX << "Cannot continue." << std::endl;
+        return 1;
+    }
+
     /// Power the system up.
     vive.serverDevProvider().LeaveStandby();
 
     std::vector<std::string> knownSerialNumbers;
     auto handleNewDevice = [&](const char *serialNum) {
-        auto dev = vive.serverDevProvider().FindTrackedDeviceDriver(
-            serialNum, vr::ITrackedDeviceServerDriver_Version);
+        auto dev = vive.serverDevProvider().FindTrackedDeviceDriver(serialNum);
         if (!dev) {
             std::cout << PREFIX
                       << "Couldn't find the corresponding device driver for "
@@ -222,8 +265,7 @@ int main() {
         std::cout << PREFIX << "Got " << numDevices
                   << " tracked devices at startup" << std::endl;
         for (decltype(numDevices) i = 0; i < numDevices; ++i) {
-            auto dev = vive.serverDevProvider().GetTrackedDeviceDriver(
-                i, vr::ITrackedDeviceServerDriver_Version);
+            auto dev = vive.serverDevProvider().GetTrackedDeviceDriver(i);
             vive.devices().addAndActivateDevice(dev);
             std::cout << PREFIX << "Device " << i << std::endl;
             whatIsThisDevice(dev);


### PR DESCRIPTION
This pull request resolves issues #14, #11, and replaces/incorporates pull request #12 (extending it by using the getinterfaceversions() call and checking the versions to ensure we're performing valid casts that won't cause crashes).

The OpenVR submodule is updated to 1.0.1, with the accompanying API changes - interface version strings were pulled from the signature of some methods. Instead, it's now essentially required for the host to verify that GetInterfaceVersions returns expected version strings to ensure the casts performed following the interface retrievals are in fact typesafe - if these checks are not done, memory corruption can result. The standalone apps as well as the OSVR plugin now all perform a check of the interface version strings and print some form of useful message if there is a meaningful mismatch.

A few smaller changes are in here, too: license updates for the property-related headers (to match OpenVR license), struct-based return values where there's a return value and an error code, signalling permanent failures from within a level of the plugin that couldn't before, avoiding unnecessary plugin work if you're running an incompatible version.

**Compatibility**:
- This plugin runs with the current SteamVR stable release on Windows: `SteamVR Version 2016-06-08 (1465424737)`
- It will not work with the current beta on Windows, which introduces a `IClientTrackedDeviceProvider_004`, which is not publicly available through the OpenVR repo.
- It does not work with the previous stable from June 1, 1464744840 (which is still available through the "betas" list in steamvr), due to the bump from `IVRDisplayComponent_001` to `IVRDisplayComponent_002` (in splitting out the oculus/controlled direct mode component), but likely would if the OpenVR submodule was rolled back to a previous version.
- I have not checked the interface symbols on any other platform than Windows at this time.