### PR TITLE
ReturnValue.h: include utility for std::move

### DIFF
--- a/ReturnValue.h
+++ b/ReturnValue.h
@@ -32,7 +32,7 @@
 // - none
 
 // Standard includes
-// - none
+#include <utility>
 
 namespace osvr {
 namespace vive {


### PR DESCRIPTION
Failed to compile under Linux without it.