### PR TITLE
Update OSVR-Vive to latest OpenVR SDK API (currently v1.0.8)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,7 +108,7 @@ add_library(ViveLoaderLib STATIC
     InterfaceTraits.h
     PropertyHelper.h
     PropertyTraits.h
-	Properties.cpp
+    Properties.cpp
     Properties.h
     Resources.cpp
     Resources.h
@@ -119,7 +119,7 @@ add_library(ViveLoaderLib STATIC
     ServerPropertyHelper.h
     Settings.cpp
     Settings.h
-	ValveStrCpy.h)
+    ValveStrCpy.h)
 target_link_libraries(ViveLoaderLib
     PUBLIC
     OpenVRDriver osvr::osvrUtil linkable_into_dll
@@ -142,7 +142,7 @@ osvr_add_plugin(com_osvr_Vive
     QuickProcessingDeque.h
     VerifyLocked.h
     "${CMAKE_CURRENT_BINARY_DIR}/com_osvr_Vive_json.h"
-	"${CMAKE_CURRENT_BINARY_DIR}/com_osvr_ViveSync_json.h")
+    "${CMAKE_CURRENT_BINARY_DIR}/com_osvr_ViveSync_json.h")
 
 target_link_libraries(com_osvr_Vive ViveLoaderLib)
 target_include_directories(com_osvr_Vive
@@ -155,7 +155,7 @@ if(BUILD_EXTRA_TOOLS)
         ViveLoader.cpp)
     target_link_libraries(ViveLoader PRIVATE ViveLoaderLib)
     copy_imported_targets(ViveLoader osvr::osvrUtil)
-	target_include_directories(ViveLoader PRIVATE ${Boost_INCLUDE_DIRS})
+    target_include_directories(ViveLoader PRIVATE ${Boost_INCLUDE_DIRS})
 
     add_executable(GenerateTypedPropertyEnums
         GenerateTypedPropertyEnums.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,29 +92,33 @@ add_library(ViveLoaderLib STATIC
     ChaperoneData.cpp
     ChaperoneData.h
     DeviceHolder.h
+    DriverContext.cpp
+    DriverContext.h
     DriverLoader.cpp
     DriverLoader.h
+    DriverLog.cpp
+    DriverLog.h
+    DriverManager.cpp
+    DriverManager.h
     DriverWrapper.h
     FindDriver.cpp
     FindDriver.h
     GetComponent.h
     GetProvider.h
     InterfaceTraits.h
+    PropertyHelper.h
+    PropertyTraits.h
+	Properties.cpp
+    Properties.h
+    Resources.cpp
+    Resources.h
     ReturnValue.h
     SearchPathExtender.h
     ServerDriverHost.cpp
     ServerDriverHost.h
     ServerPropertyHelper.h
-    PropertyHelper.h
-    PropertyTraits.h
-	Properties.h
-	Properties.cpp
     Settings.cpp
     Settings.h
-    DriverLog.h
-    DriverLog.cpp
-	DriverContext.h
-	DriverContext.cpp
 	ValveStrCpy.h)
 target_link_libraries(ViveLoaderLib
     PUBLIC

--- a/DisplayExtractor.cpp
+++ b/DisplayExtractor.cpp
@@ -270,6 +270,32 @@ int main() {
                       << std::endl;
             return 1;
         }
+
+        auto handleNewDevice = [&](const char *serialNum,
+                                   vr::ETrackedDeviceClass eDeviceClass,
+                                   vr::ITrackedDeviceServerDriver *pDriver) {
+            auto dev = pDriver;
+            if (!dev) {
+                std::cout << PREFIX << "null input device" << std::endl;
+                return false;
+            }
+            auto ret = vive.devices().addAndActivateDevice(dev);
+            if (!ret) {
+                std::cout << PREFIX << "Device with serial number " << serialNum
+                          << " couldn't be added to the devices vector."
+                          << std::endl;
+                return false;
+            }
+            std::cout << "\n"
+                      << PREFIX << "Device with s/n " << serialNum
+                      << " activated, assigned ID " << ret.value << std::endl;
+            vr::TrackedDeviceIndex_t idx = ret.value;
+
+            return true;
+        };
+
+        vive.driverHost().onTrackedDeviceAdded = handleNewDevice;
+
         if (!vive.startServerDeviceProvider()) {
             // can either check return value of this, or do another if (!vive)
             // after calling - equivalent.

--- a/DriverContext.cpp
+++ b/DriverContext.cpp
@@ -35,13 +35,17 @@ using namespace vr;
 
 DriverContext::DriverContext()
     : m_pServerDriverHost(nullptr), m_pVRProperties(nullptr),
-      m_pVRSetting(nullptr), m_pVRDriverLog(nullptr) {}
+      m_pVRSetting(nullptr), m_pVRDriverLog(nullptr),
+      m_pVRDriverManager(nullptr), m_pVRResources(nullptr) {}
 
 DriverContext::DriverContext(vr::ServerDriverHost *serverDriverHost,
                              vr::Settings *settings, vr::DriverLog *driverLog,
-                             vr::Properties *properties)
+                             vr::Properties *properties,
+                             vr::DriverManager *driverManager,
+                             vr::Resources *resources)
     : m_pServerDriverHost(serverDriverHost), m_pVRProperties(properties),
-      m_pVRSetting(settings), m_pVRDriverLog(driverLog) {}
+      m_pVRSetting(settings), m_pVRDriverLog(driverLog),
+      m_pVRDriverManager(driverManager), m_pVRResources(resources) {}
 
 // only consider four type of interfaces
 void *DriverContext::GetGenericInterface(const char *pchInterfaceVersion,
@@ -55,6 +59,10 @@ void *DriverContext::GetGenericInterface(const char *pchInterfaceVersion,
         return m_pVRProperties;
     } else if (interfaceVersion.compare(IVRDriverLog_Version) == 0) {
         return m_pVRDriverLog;
+    } else if (interfaceVersion.compare(IVRDriverManager_Version) == 0) {
+        return m_pVRDriverManager;
+    } else if (interfaceVersion.compare(IVRResources_Version) == 0) {
+        return m_pVRResources;
     } else {
         std::string errMsg = "Got an unhandled interface type version - " +
                              std::string(pchInterfaceVersion);

--- a/DriverContext.h
+++ b/DriverContext.h
@@ -27,7 +27,9 @@
 
 // Internal
 #include "DriverLog.h"
+#include "DriverManager.h"
 #include "Properties.h"
+#include "Resources.h"
 #include "ServerDriverHost.h"
 #include "Settings.h"
 
@@ -46,7 +48,8 @@ class DriverContext : public vr::IVRDriverContext {
     DriverContext();
     DriverContext(vr::ServerDriverHost *serverDriverHost,
                   vr::Settings *settings, vr::DriverLog *driverLog,
-                  vr::Properties *properties);
+                  vr::Properties *properties, vr::DriverManager *driverManager,
+                  vr::Resources *resources);
 
     /// Returns the requested interface. If the interface was not available
     /// it will return NULL and fill out the error.
@@ -61,6 +64,8 @@ class DriverContext : public vr::IVRDriverContext {
     vr::IVRProperties *m_pVRProperties;
     vr::IVRSettings *m_pVRSetting;
     vr::IVRDriverLog *m_pVRDriverLog;
+    vr::IVRDriverManager *m_pVRDriverManager;
+    vr::IVRResources *m_pVRResources;
 };
 
 } // namespace vr

--- a/DriverManager.cpp
+++ b/DriverManager.cpp
@@ -1,0 +1,53 @@
+/** @file
+    @brief Implementation
+
+    @date 2017
+
+    @author
+    Sensics, Inc.
+    <http://sensics.com/osvr>
+*/
+
+// Copyright 2017 Sensics, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Internal Includes
+#include "DriverManager.h"
+#include "ValveStrCpy.h"
+
+// Library/third-party includes
+// - none
+
+// Standard includes
+// - none
+
+using namespace vr;
+
+DriverManager::DriverManager()
+    : m_logger(osvr::util::log::make_logger("DriverManager")) {}
+
+uint32_t DriverManager::GetDriverCount() const {
+    m_logger->info("GetDriverCount");
+    return 1;
+}
+uint32_t DriverManager::GetDriverName(vr::DriverId_t nDriver, char *pchValue,
+                                      uint32_t unBufferSize) {
+    m_logger->info("GetDriverName(") << nDriver << "," << unBufferSize << ")";
+    const std::string driverName = "lighthouse";
+    if (unBufferSize > driverName.size()) {
+        auto ret = valveStrCpy(driverName, pchValue, driverName.size());
+        return ret;
+    }
+    return 0;
+}

--- a/DriverManager.cpp
+++ b/DriverManager.cpp
@@ -46,7 +46,7 @@ uint32_t DriverManager::GetDriverName(vr::DriverId_t nDriver, char *pchValue,
     m_logger->debug("GetDriverName(") << nDriver << "," << unBufferSize << ")";
     const std::string driverName = "lighthouse";
     if (unBufferSize > driverName.size()) {
-        auto ret = valveStrCpy(driverName, pchValue, driverName.size());
+        auto ret = valveStrCpy(driverName, pchValue, unBufferSize);
         return ret;
     }
     return 0;

--- a/DriverManager.cpp
+++ b/DriverManager.cpp
@@ -38,12 +38,12 @@ DriverManager::DriverManager()
     : m_logger(osvr::util::log::make_logger("DriverManager")) {}
 
 uint32_t DriverManager::GetDriverCount() const {
-    m_logger->info("GetDriverCount");
+    m_logger->debug("GetDriverCount");
     return 1;
 }
 uint32_t DriverManager::GetDriverName(vr::DriverId_t nDriver, char *pchValue,
                                       uint32_t unBufferSize) {
-    m_logger->info("GetDriverName(") << nDriver << "," << unBufferSize << ")";
+    m_logger->debug("GetDriverName(") << nDriver << "," << unBufferSize << ")";
     const std::string driverName = "lighthouse";
     if (unBufferSize > driverName.size()) {
         auto ret = valveStrCpy(driverName, pchValue, driverName.size());

--- a/DriverManager.h
+++ b/DriverManager.h
@@ -1,0 +1,51 @@
+/** @file
+    @brief Header
+
+    @date 2017
+
+    @author
+    Sensics, Inc.
+    <http://sensics.com/osvr>
+*/
+
+// Copyright 2017 Sensics, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef INCLUDED_DriverManager_h_GUID_BC08BDF5_CBD0_4DAF_F30F_43DE8357A43B
+#define INCLUDED_DriverManager_h_GUID_BC08BDF5_CBD0_4DAF_F30F_43DE8357A43B
+
+// Internal Includes
+#include <osvr/Util/Logger.h>
+
+// Library/third-party includes
+#include <openvr_driver.h>
+
+// Standard includes
+#include <cstdint>
+
+namespace vr {
+
+class DriverManager : public vr::IVRDriverManager {
+  public:
+    DriverManager();
+    virtual uint32_t GetDriverCount() const;
+    virtual uint32_t GetDriverName(vr::DriverId_t nDriver, char *pchValue,
+                                   uint32_t unBufferSize);
+  private:
+    osvr::util::log::LoggerPtr m_logger;
+};
+
+} // namespace vr
+
+#endif // INCLUDED_DriverManager_h_GUID_BC08BDF5_CBD0_4DAF_F30F_43DE8357A43B

--- a/DriverManager.h
+++ b/DriverManager.h
@@ -39,9 +39,19 @@ namespace vr {
 class DriverManager : public vr::IVRDriverManager {
   public:
     DriverManager();
+    /**
+    @brief This function always returns 1, since we're only using lighthouse
+    driver
+    */
     virtual uint32_t GetDriverCount() const;
+    /**
+    @brief Determine and store path to the SteamVR driver for given nDriver id
+    The resulting path is stored as placeholder string {pchValue}
+    It is used by IVRResources impl to load files specified by path
+    */
     virtual uint32_t GetDriverName(vr::DriverId_t nDriver, char *pchValue,
                                    uint32_t unBufferSize);
+
   private:
     osvr::util::log::LoggerPtr m_logger;
 };

--- a/DriverWrapper.h
+++ b/DriverWrapper.h
@@ -31,9 +31,11 @@
 #include "DriverContext.h"
 #include "DriverLoader.h"
 #include "DriverLog.h"
+#include "DriverManager.h"
 #include "FindDriver.h"
 #include "GetProvider.h"
 #include "Properties.h"
+#include "Resources.h"
 #include "ServerDriverHost.h"
 #include "Settings.h"
 
@@ -270,8 +272,11 @@ namespace vive {
             settings_ = new vr::Settings();
             driverLog_ = new vr::DriverLog();
             properties_ = new vr::Properties();
-            context_ = new vr::DriverContext(serverDriverHost_, settings_,
-                                             driverLog_, properties_);
+            driverManager_ = new vr::DriverManager();
+            resources_ = new vr::Resources();
+            context_ =
+                new vr::DriverContext(serverDriverHost_, settings_, driverLog_,
+                                      properties_, driverManager_, resources_);
 
             vr::EVRInitError err;
             err = Init();
@@ -434,6 +439,8 @@ namespace vive {
         vr::Settings *settings_;
         vr::DriverLog *driverLog_;
         vr::Properties *properties_;
+        vr::DriverManager *driverManager_;
+        vr::Resources *resources_;
     };
 } // namespace vive
 } // namespace osvr

--- a/PropertyTraits.h
+++ b/PropertyTraits.h
@@ -64,7 +64,7 @@ namespace vive {
         WillDriftInYaw = vr::Prop_WillDriftInYaw_Bool,
         ManufacturerName = vr::Prop_ManufacturerName_String,
         TrackingFirmwareVersion = vr::Prop_TrackingFirmwareVersion_String,
-        // shortcut omitted due to ambiguity for Prop_HardwareRevision_String
+        HardwareRevision_String = vr::Prop_HardwareRevision_String,
         AllWirelessDongleDescriptions =
             vr::Prop_AllWirelessDongleDescriptions_String,
         ConnectedWirelessDongle = vr::Prop_ConnectedWirelessDongle_String,
@@ -75,7 +75,7 @@ namespace vive {
         Firmware_UpdateAvailable = vr::Prop_Firmware_UpdateAvailable_Bool,
         Firmware_ManualUpdate = vr::Prop_Firmware_ManualUpdate_Bool,
         Firmware_ManualUpdateURL = vr::Prop_Firmware_ManualUpdateURL_String,
-        // shortcut omitted due to ambiguity for Prop_HardwareRevision_Uint64
+        HardwareRevision_Uint64 = vr::Prop_HardwareRevision_Uint64,
         FirmwareVersion = vr::Prop_FirmwareVersion_Uint64,
         FPGAVersion = vr::Prop_FPGAVersion_Uint64,
         VRCVersion = vr::Prop_VRCVersion_Uint64,
@@ -95,6 +95,7 @@ namespace vive {
             vr::Prop_Firmware_ForceUpdateRequired_Bool,
         ViveSystemButtonFixRequired = vr::Prop_ViveSystemButtonFixRequired_Bool,
         ParentDriver = vr::Prop_ParentDriver_Uint64,
+        ResourceRoot = vr::Prop_ResourceRoot_String,
         ReportsTimeSinceVSync = vr::Prop_ReportsTimeSinceVSync_Bool,
         SecondsFromVsyncToPhotons = vr::Prop_SecondsFromVsyncToPhotons_Float,
         DisplayFrequency = vr::Prop_DisplayFrequency_Float,
@@ -139,7 +140,11 @@ namespace vive {
         DisplayMCImageHeight = vr::Prop_DisplayMCImageHeight_Int32,
         DisplayMCImageNumChannels = vr::Prop_DisplayMCImageNumChannels_Int32,
         DisplayMCImageData = vr::Prop_DisplayMCImageData_Binary,
-        UsesDriverDirectMode = vr::Prop_UsesDriverDirectMode_Bool,
+        SecondsFromPhotonsToVblank = vr::Prop_SecondsFromPhotonsToVblank_Float,
+        DriverDirectModeSendsVsyncEvents =
+            vr::Prop_DriverDirectModeSendsVsyncEvents_Bool,
+        DisplayDebugMode = vr::Prop_DisplayDebugMode_Bool,
+        GraphicsAdapterLuid = vr::Prop_GraphicsAdapterLuid_Uint64,
         AttachedDeviceId = vr::Prop_AttachedDeviceId_String,
         SupportedButtons = vr::Prop_SupportedButtons_Uint64,
         Axis0Type = vr::Prop_Axis0Type_Int32,
@@ -170,7 +175,13 @@ namespace vive {
         NamedIconPathDeviceAlertLow =
             vr::Prop_NamedIconPathDeviceAlertLow_String,
         UserConfigPath = vr::Prop_UserConfigPath_String,
-        InstallPath = vr::Prop_InstallPath_String
+        InstallPath = vr::Prop_InstallPath_String,
+        HasDisplayComponent = vr::Prop_HasDisplayComponent_Bool,
+        HasControllerComponent = vr::Prop_HasControllerComponent_Bool,
+        HasCameraComponent = vr::Prop_HasCameraComponent_Bool,
+        HasDriverDirectModeComponent =
+            vr::Prop_HasDriverDirectModeComponent_Bool,
+        HasVirtualDisplayComponent = vr::Prop_HasVirtualDisplayComponent_Bool
     };
     namespace detail {
         template <std::size_t EnumVal> struct PropertyTypeTrait;
@@ -298,6 +309,9 @@ namespace vive {
         };
         template <> struct PropertyTypeTrait<vr::Prop_ParentDriver_Uint64> {
             using type = uint64_t;
+        };
+        template <> struct PropertyTypeTrait<vr::Prop_ResourceRoot_String> {
+            using type = std::string;
         };
         template <>
         struct PropertyTypeTrait<vr::Prop_ReportsTimeSinceVSync_Bool> {
@@ -452,8 +466,20 @@ namespace vive {
             using type = void *;
         };
         template <>
-        struct PropertyTypeTrait<vr::Prop_UsesDriverDirectMode_Bool> {
+        struct PropertyTypeTrait<vr::Prop_SecondsFromPhotonsToVblank_Float> {
+            using type = float;
+        };
+        template <>
+        struct PropertyTypeTrait<
+            vr::Prop_DriverDirectModeSendsVsyncEvents_Bool> {
             using type = bool;
+        };
+        template <> struct PropertyTypeTrait<vr::Prop_DisplayDebugMode_Bool> {
+            using type = bool;
+        };
+        template <>
+        struct PropertyTypeTrait<vr::Prop_GraphicsAdapterLuid_Uint64> {
+            using type = uint64_t;
         };
         template <> struct PropertyTypeTrait<vr::Prop_AttachedDeviceId_String> {
             using type = std::string;
@@ -549,6 +575,25 @@ namespace vive {
         };
         template <> struct PropertyTypeTrait<vr::Prop_InstallPath_String> {
             using type = std::string;
+        };
+        template <>
+        struct PropertyTypeTrait<vr::Prop_HasDisplayComponent_Bool> {
+            using type = bool;
+        };
+        template <>
+        struct PropertyTypeTrait<vr::Prop_HasControllerComponent_Bool> {
+            using type = bool;
+        };
+        template <> struct PropertyTypeTrait<vr::Prop_HasCameraComponent_Bool> {
+            using type = bool;
+        };
+        template <>
+        struct PropertyTypeTrait<vr::Prop_HasDriverDirectModeComponent_Bool> {
+            using type = bool;
+        };
+        template <>
+        struct PropertyTypeTrait<vr::Prop_HasVirtualDisplayComponent_Bool> {
+            using type = bool;
         };
     } // namespace detail
 

--- a/Resources.cpp
+++ b/Resources.cpp
@@ -1,0 +1,50 @@
+/** @file
+    @brief Implementation
+
+    @date 2017
+
+    @author
+    Sensics, Inc.
+    <http://sensics.com/osvr>
+*/
+
+// Copyright 2017 Sensics, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Internal Includes
+#include "Resources.h"
+
+// Library/third-party includes
+// - none
+
+// Standard includes
+// - none
+
+using namespace vr;
+
+Resources::Resources() : m_logger(osvr::util::log::make_logger("Resources")) {}
+
+uint32_t Resources::LoadSharedResource(const char *pchResourceName,
+                                       char *pchBuffer, uint32_t unBufferLen) {
+    m_logger->info("LoadSharedResource(") << pchResourceName << ")";
+    return 0;
+}
+uint32_t Resources::GetResourceFullPath(const char *pchResourceName,
+                                        const char *pchResourceTypeDirectory,
+                                        char *pchPathBuffer,
+                                        uint32_t unBufferLen) {
+    m_logger->info("GetResourceFullPath(")
+        << pchResourceName << ", " << pchResourceTypeDirectory << ")";
+    return 0;
+}

--- a/Resources.cpp
+++ b/Resources.cpp
@@ -37,14 +37,14 @@ Resources::Resources() : m_logger(osvr::util::log::make_logger("Resources")) {}
 
 uint32_t Resources::LoadSharedResource(const char *pchResourceName,
                                        char *pchBuffer, uint32_t unBufferLen) {
-    m_logger->info("LoadSharedResource(") << pchResourceName << ")";
+    m_logger->debug("LoadSharedResource(") << pchResourceName << ")";
     return 0;
 }
 uint32_t Resources::GetResourceFullPath(const char *pchResourceName,
                                         const char *pchResourceTypeDirectory,
                                         char *pchPathBuffer,
                                         uint32_t unBufferLen) {
-    m_logger->info("GetResourceFullPath(")
+    m_logger->debug("GetResourceFullPath(")
         << pchResourceName << ", " << pchResourceTypeDirectory << ")";
     return 0;
 }

--- a/Resources.h
+++ b/Resources.h
@@ -1,0 +1,54 @@
+/** @file
+    @brief Header
+
+    @date 2017
+
+    @author
+    Sensics, Inc.
+    <http://sensics.com/osvr>
+*/
+
+// Copyright 2017 Sensics, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef INCLUDED_Resources_h_GUID_693D9495_1559_4899_9D4E_7825D29AE2AC
+#define INCLUDED_Resources_h_GUID_693D9495_1559_4899_9D4E_7825D29AE2AC
+
+// Internal Includes
+#include <osvr/Util/Logger.h>
+
+// Library/third-party includes
+#include <openvr_driver.h>
+
+// Standard includes
+
+namespace vr {
+
+class Resources : public vr::IVRResources {
+  public:
+    Resources();
+    virtual uint32_t LoadSharedResource(const char *pchResourceName,
+                                        char *pchBuffer, uint32_t unBufferLen);
+    virtual uint32_t GetResourceFullPath(const char *pchResourceName,
+                                         const char *pchResourceTypeDirectory,
+                                         char *pchPathBuffer,
+                                         uint32_t unBufferLen);
+
+  private:
+    osvr::util::log::LoggerPtr m_logger;
+};
+
+} // namespace vr
+
+#endif // INCLUDED_Resources_h_GUID_693D9495_1559_4899_9D4E_7825D29AE2AC

--- a/ServerDriverHost.cpp
+++ b/ServerDriverHost.cpp
@@ -117,3 +117,12 @@ bool ServerDriverHost::PollNextEvent(VREvent_t *pEvent, uint32_t uncbVREvent) {
     logger_->debug("PollNextEvent(") << uncbVREvent << ")";
     return false;
 }
+
+void ServerDriverHost::GetRawTrackedDevicePoses(
+    float fPredictedSecondsFromNow,
+    TrackedDevicePose_t *pTrackedDevicePoseArray,
+    uint32_t unTrackedDevicePoseArrayCount) {
+    logger_->info("GetRawTrackedDevicePoses(")
+        << fPredictedSecondsFromNow << ", " << unTrackedDevicePoseArrayCount
+        << ")";
+}

--- a/ServerDriverHost.cpp
+++ b/ServerDriverHost.cpp
@@ -38,11 +38,11 @@ vr::ServerDriverHost::ServerDriverHost()
 bool ServerDriverHost::TrackedDeviceAdded(const char *pchDeviceSerialNumber,
                                           ETrackedDeviceClass eDeviceClass,
                                           ITrackedDeviceServerDriver *pDriver) {
+    logger_->info("TrackedDeviceAdded(") << pchDeviceSerialNumber << ")";
     if (onTrackedDeviceAdded) {
         return onTrackedDeviceAdded(pchDeviceSerialNumber, eDeviceClass,
                                     pDriver);
     }
-    logger_->info("TrackedDeviceAdded(") << pchDeviceSerialNumber << ")";
     return true;
 }
 
@@ -122,7 +122,7 @@ void ServerDriverHost::GetRawTrackedDevicePoses(
     float fPredictedSecondsFromNow,
     TrackedDevicePose_t *pTrackedDevicePoseArray,
     uint32_t unTrackedDevicePoseArrayCount) {
-    logger_->info("GetRawTrackedDevicePoses(")
+    logger_->debug("GetRawTrackedDevicePoses(")
         << fPredictedSecondsFromNow << ", " << unTrackedDevicePoseArrayCount
         << ")";
 }

--- a/ServerDriverHost.h
+++ b/ServerDriverHost.h
@@ -93,6 +93,11 @@ class ServerDriverHost : public vr::IVRServerDriverHost {
 
     virtual bool PollNextEvent(VREvent_t *pEvent, uint32_t uncbVREvent);
 
+    virtual void
+    GetRawTrackedDevicePoses(float fPredictedSecondsFromNow,
+                             TrackedDevicePose_t *pTrackedDevicePoseArray,
+                             uint32_t unTrackedDevicePoseArrayCount);
+
     IVRSettings *vrSettings = nullptr;
 
   private:

--- a/ViveLoader.cpp
+++ b/ViveLoader.cpp
@@ -57,8 +57,9 @@ static void whatIsThisDevice(vr::ITrackedDeviceServerDriver *dev,
                 std::cout << PREFIX << " -- Tracking universe not yet known"
                           << std::endl;
             } else {
-                std::cout << PREFIX << " -- Some other error trying to figure "
-                                       "out the tracking universe: "
+                std::cout << PREFIX
+                          << " -- Some other error trying to figure "
+                             "out the tracking universe: "
                           << err << std::endl;
             }
         }
@@ -209,14 +210,16 @@ int main() {
     auto interfaceStatus = vive.checkServerDeviceProviderInterfaces();
     switch (interfaceStatus) {
     case osvr::vive::DriverWrapper::InterfaceVersionStatus::AllInterfacesOK:
-        std::cerr << PREFIX << "All interface versions mentioned by the driver "
-                               "are available and supported."
+        std::cerr << PREFIX
+                  << "All interface versions mentioned by the driver "
+                     "are available and supported."
                   << std::endl;
         break;
     case osvr::vive::DriverWrapper::InterfaceVersionStatus::AllUsedInterfacesOK:
-        std::cerr << PREFIX << "Not all interface versions mentioned by the "
-                               "driver are available and supported, but the "
-                               "ones used by this code match."
+        std::cerr << PREFIX
+                  << "Not all interface versions mentioned by the "
+                     "driver are available and supported, but the "
+                     "ones used by this code match."
                   << std::endl;
         break;
     case osvr::vive::DriverWrapper::InterfaceVersionStatus::InterfaceMismatch:
@@ -252,20 +255,18 @@ int main() {
     /// Power the system up.
     vive.serverDevProvider().LeaveStandby();
 
-    std::vector<std::string> knownSerialNumbers;
-
 #if 0
-     {
-     auto numDevices = vive.serverDevProvider().GetTrackedDeviceCount();
-     std::cout << PREFIX << "Got " << numDevices
-     << " tracked devices at startup" << std::endl;
-     for (decltype(numDevices) i = 0; i < numDevices; ++i) {
-     auto dev = vive.serverDevProvider().GetTrackedDeviceDriver(i);
-     vive.devices().addAndActivateDevice(dev);
-     std::cout << PREFIX << "Device " << i << std::endl;
-     whatIsThisDevice(dev);
-     }
-     }
+    {
+        osvr::vive::DeviceHolder devHolder = std::move(vive.devices());
+        auto numDevices = devHolder.numDevices();
+        std::cout << PREFIX << "Got " << numDevices
+                  << " tracked devices at startup" << std::endl;
+        for (decltype(numDevices) i = 0; i < numDevices; ++i) {
+            vr::ITrackedDeviceServerDriver *dev = &(devHolder.getDevice(i));
+            std::cout << PREFIX << "Device " << i << std::endl;
+            whatIsThisDevice(dev, i);
+        }
+    }
 #endif
     std::cout << "*** Entering dummy mainloop" << std::endl;
 #if 1


### PR DESCRIPTION
This PR updates the OpenVR SDK to 1.0.8 and adds required implementations of new interfaces IVRResources nad IVRDriverManager.