### PR TITLE
Openvr109

### DIFF
--- a/PropertyTraits.h
+++ b/PropertyTraits.h
@@ -145,6 +145,9 @@ namespace vive {
             vr::Prop_DriverDirectModeSendsVsyncEvents_Bool,
         DisplayDebugMode = vr::Prop_DisplayDebugMode_Bool,
         GraphicsAdapterLuid = vr::Prop_GraphicsAdapterLuid_Uint64,
+        DriverProvidedChaperonePath_String =
+            vr::Prop_DriverProvidedChaperonePath_String,
+
         AttachedDeviceId = vr::Prop_AttachedDeviceId_String,
         SupportedButtons = vr::Prop_SupportedButtons_Uint64,
         Axis0Type = vr::Prop_Axis0Type_Int32,
@@ -477,6 +480,11 @@ namespace vive {
         template <> struct PropertyTypeTrait<vr::Prop_DisplayDebugMode_Bool> {
             using type = bool;
         };
+
+        template <> struct PropertyTypeTrait<vr::Prop_DriverProvidedChaperonePath_String> {
+            using type = std::string;
+        };
+
         template <>
         struct PropertyTypeTrait<vr::Prop_GraphicsAdapterLuid_Uint64> {
             using type = uint64_t;

--- a/ServerDriverHost.cpp
+++ b/ServerDriverHost.cpp
@@ -126,3 +126,14 @@ void ServerDriverHost::GetRawTrackedDevicePoses(
         << fPredictedSecondsFromNow << ", " << unTrackedDevicePoseArrayCount
         << ")";
 }
+
+void ServerDriverHost::TrackedDeviceDisplayTransformUpdated(
+        uint32_t unWhichDevice,
+        HmdMatrix34_t eyeToHeadLeft,
+        HmdMatrix34_t eyeToHeadRight) {
+    logger_->debug("TrackedDeviceDisplayTransformUpdated(")
+        << unWhichDevice << ", eyeToHeadLeft, eyeToHeadRight)";
+        //<< eyeToHeadLeft << ", "
+        //<< eyeToHeadRight << ")";
+}
+

--- a/ServerDriverHost.h
+++ b/ServerDriverHost.h
@@ -98,6 +98,9 @@ class ServerDriverHost : public vr::IVRServerDriverHost {
                              TrackedDevicePose_t *pTrackedDevicePoseArray,
                              uint32_t unTrackedDevicePoseArrayCount);
 
+    virtual void TrackedDeviceDisplayTransformUpdated(uint32_t unWhichDevice,
+                                                      HmdMatrix34_t eyeToHeadLeft,
+                                                      HmdMatrix34_t eyeToHeadRight);
     IVRSettings *vrSettings = nullptr;
 
   private:


### PR DESCRIPTION
First and __incomplete__ pass at upgrading to OpenVR SDK 1.0.9. looking for pointers and feedback. These commits build for me and allow the use of the latest stable steamvr lighthouse drivers.